### PR TITLE
Add SEA to GeoRegionEnum.php

### DIFF
--- a/src/Riot/Enum/GeoRegionEnum.php
+++ b/src/Riot/Enum/GeoRegionEnum.php
@@ -10,6 +10,7 @@ use MyCLabs\Enum\Enum;
  * @method static self AMERICAS()
  * @method static self ASIA()
  * @method static self EUROPE()
+ * @method static self SEA()
  *
  * @extends Enum<string>
  * @psalm-immutable
@@ -19,4 +20,5 @@ final class GeoRegionEnum extends Enum
     private const AMERICAS = 'americas';
     private const ASIA = 'asia';
     private const EUROPE = 'europe';
+    private const SEA = 'sea';
 }


### PR DESCRIPTION
SEA is a fourth region within the leaderboards of Legends of Runeterra.
https://developer.riotgames.com/apis#lor-ranked-v1